### PR TITLE
chore: Add Terser to minify lib code on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "nx": "14.7.13",
     "prettier": "^2.6.2",
     "react-test-renderer": "18.2.0",
+    "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "28.0.5",
     "ts-node": "10.9.1",
     "typescript": "~4.8.2",

--- a/packages/react-forms/project.json
+++ b/packages/react-forms/project.json
@@ -13,7 +13,7 @@
         "project": "packages/react-forms/package.json",
         "entryFile": "packages/react-forms/src/index.ts",
         "external": ["react/jsx-runtime"],
-        "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+        "rollupConfig": "rollup.config",
         "compiler": "babel",
         "extractCss": "style.css",
         "assets": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,10 @@
+const nxRollupConfig = require('@nrwl/react/plugins/bundle-rollup');
+const { terser } = require('rollup-plugin-terser');
+
+module.exports = function getRollupOptions(options) {
+  const nxOptions = nxRollupConfig(options);
+  return {
+    ...nxOptions,
+    plugins: [...(nxOptions.plugins || []), terser()],
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,6 +1946,7 @@ __metadata:
     react-is: 18.2.0
     react-test-renderer: 18.2.0
     regenerator-runtime: 0.13.7
+    rollup-plugin-terser: ^7.0.2
     styled-components: 5.3.5
     ts-jest: 28.0.5
     ts-node: 10.9.1
@@ -13830,7 +13831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^26.5.0, jest-worker@npm:^26.6.2":
+"jest-worker@npm:^26.2.1, jest-worker@npm:^26.5.0, jest-worker@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-worker@npm:26.6.2"
   dependencies:
@@ -18188,6 +18189,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup-plugin-terser@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "rollup-plugin-terser@npm:7.0.2"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    jest-worker: ^26.2.1
+    serialize-javascript: ^4.0.0
+    terser: ^5.0.0
+  peerDependencies:
+    rollup: ^2.0.0
+  checksum: af84bb7a7a894cd00852b6486528dfb8653cf94df4c126f95f389a346f401d054b08c46bee519a2ab6a22b33804d1d6ac6d8c90b1b2bf8fffb097eed73fc3c72
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-typescript2@npm:^0.31.1":
   version: 0.31.2
   resolution: "rollup-plugin-typescript2@npm:0.31.2"
@@ -19804,7 +19819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser@npm:^5.10.0, terser@npm:^5.14.1, terser@npm:^5.3.4":
+"terser@npm:^5.0.0, terser@npm:^5.10.0, terser@npm:^5.14.1, terser@npm:^5.3.4":
   version: 5.15.0
   resolution: "terser@npm:5.15.0"
   dependencies:


### PR DESCRIPTION
As (for now) the web/rollup builder from Nx doesn't include a minify step, this PR adds a custom config for rollup to add the Terser plugin. 