### PR TITLE
Force versions to fix Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "resolutions": {
     "meow": "11.0.0",
     "chokidar": "3.5.3",
-    "globby": "11.1.0"
+    "globby": "11.1.0",
+    "trim": "0.0.3"
   },
   "workspaces": [
     "packages/**"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19652,10 +19652,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trim@npm:0.0.1":
-  version: 0.0.1
-  resolution: "trim@npm:0.0.1"
-  checksum: 2b4646dff99a222e8e1526edd4e3a43bbd925af0b8e837c340455d250157e7deefaa4da49bb891ab841e5c27b1afc5e9e32d4b57afb875d2dfcabf4e319b8f7f
+"trim@npm:0.0.3":
+  version: 0.0.3
+  resolution: "trim@npm:0.0.3"
+  checksum: 9a059ba56d5e22c9e571798a7c63640cb25478c495d8a9d001f6352927207c6bd224018751a0c5145fbedc943ee2ebab1d7cc2e8ccba3121a51a7d3428dd879c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR forces resolution of some indirect dependencies to fix Dependabot alerts. Most of them should be fixed by the version 7 of StoryBook, but it is still in alpha at the moment. 