### PR TITLE
Fix Rollup config

### DIFF
--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -2,5 +2,13 @@
   "name": "@heetch/react-forms",
   "version": "1.0.0",
   "license": "MIT",
-  "author": "Heetch"
+  "author": "Heetch",
+  "peerDependencies": {
+    "@heetch/flamingo-react": "^5.2.0",
+    "@react-hook/window-size": "^3.1.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.35.0",
+    "styled-components": "5.3.5"
+  }
 }

--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heetch/react-forms",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "author": "Heetch",
   "peerDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,5 +6,6 @@ module.exports = function getRollupOptions(options) {
   return {
     ...nxOptions,
     plugins: [...(nxOptions.plugins || []), terser()],
+    external: ['react', 'react-dom'],
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,6 +1885,13 @@ __metadata:
 "@heetch/react-forms@workspace:packages/react-forms":
   version: 0.0.0-use.local
   resolution: "@heetch/react-forms@workspace:packages/react-forms"
+  peerDependencies:
+    "@heetch/flamingo-react": ^5.2.0
+    "@react-hook/window-size": ^3.1.1
+    react: 18.2.0
+    react-dom: 18.2.0
+    react-hook-form: ^7.35.0
+    styled-components: 5.3.5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
For some obscure reason, a library built with Rollup, and that uses styled-components needs a specific config so that it can be used properly in an app. Otherwise, a very cryptic error (`cannot read properties of null`-like) occurs. 