### PR TITLE
Remove styled components

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@babel/core": "7.12.13",
     "@babel/preset-typescript": "7.12.13",
+    "@heetch/flamingo-react": "^5.2.0",
     "@nrwl/cli": "14.8.4",
     "@nrwl/eslint-plugin-nx": "14.8.4",
     "@nrwl/jest": "14.8.4",
@@ -61,6 +62,7 @@
     "prettier": "^2.6.2",
     "react-test-renderer": "18.2.0",
     "rollup-plugin-terser": "^7.0.2",
+    "styled-components": "^5.1.0",
     "ts-jest": "28.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.8.4",
@@ -78,15 +80,11 @@
   ],
   "packageManager": "yarn@3.2.3",
   "dependencies": {
-    "@heetch/flamingo-react": "^5.2.0",
-    "@react-hook/window-size": "^3.1.1",
     "core-js": "^3.6.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-hook-form": "^7.35.0",
     "react-is": "18.2.0",
     "regenerator-runtime": "0.13.7",
-    "styled-components": "5.3.5",
     "tslib": "^2.3.0"
   }
 }

--- a/packages/react-forms/.babelrc
+++ b/packages/react-forms/.babelrc
@@ -8,5 +8,5 @@
       }
     ]
   ],
-  "plugins": [["styled-components", { "pure": true, "ssr": true }]]
+  "plugins": []
 }

--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -3,12 +3,16 @@
   "version": "1.0.1",
   "license": "MIT",
   "author": "Heetch",
+  "devDependencies": {
+    "@react-hook/window-size": "^3.1.1",
+    "react-hook-form": "^7.35.0"
+  },
   "peerDependencies": {
     "@heetch/flamingo-react": "^5.2.0",
     "@react-hook/window-size": "^3.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.35.0",
-    "styled-components": "5.3.5"
+    "styled-components": "^5.1.0"
   }
 }

--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heetch/react-forms",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "author": "Heetch",
   "devDependencies": {

--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -12,7 +12,6 @@
     "@react-hook/window-size": "^3.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-hook-form": "^7.35.0",
-    "styled-components": "^5.1.0"
+    "react-hook-form": "^7.35.0"
   }
 }

--- a/packages/react-forms/project.json
+++ b/packages/react-forms/project.json
@@ -13,7 +13,7 @@
         "project": "packages/react-forms/package.json",
         "entryFile": "packages/react-forms/src/index.ts",
         "external": ["react/jsx-runtime"],
-        "rollupConfig": "rollup.config",
+        "rollupConfig": "packages/react-forms/rollup.config",
         "compiler": "babel",
         "extractCss": "style.css",
         "assets": [

--- a/packages/react-forms/rollup.config.js
+++ b/packages/react-forms/rollup.config.js
@@ -6,6 +6,12 @@ module.exports = function getRollupOptions(options) {
   return {
     ...nxOptions,
     plugins: [...(nxOptions.plugins || []), terser()],
-    external: ['react', 'react-dom'],
+    external: [
+      'react',
+      'react-dom',
+      '@heetch/flamingo-react',
+      '@react-hook/window-size',
+      'react-hook-form',
+    ],
   };
 };

--- a/packages/react-forms/src/lib/error-helper/error-helper.module.scss
+++ b/packages/react-forms/src/lib/error-helper/error-helper.module.scss
@@ -1,0 +1,4 @@
+.ErrorHelper {
+  margin-top: 0;
+  color: var(--f-color-feedback-error) !important;
+}

--- a/packages/react-forms/src/lib/error-helper/error-helper.tsx
+++ b/packages/react-forms/src/lib/error-helper/error-helper.tsx
@@ -1,0 +1,7 @@
+import { PropsWithChildren } from 'react';
+import { Helper } from '@heetch/flamingo-react';
+import styles from './error-helper.module.scss';
+
+export const ErrorHelper = ({ children }: PropsWithChildren) => {
+  return <Helper className={styles['ErrorHelper']}>{children}</Helper>;
+};

--- a/packages/react-forms/src/lib/form-field-date-renderer/form-field-date-renderer.tsx
+++ b/packages/react-forms/src/lib/form-field-date-renderer/form-field-date-renderer.tsx
@@ -14,7 +14,7 @@ import {
   isRequired,
   MOBILE_BREAKPOINT,
 } from '../../utils';
-import { ErrorHelper } from '../styled-components';
+import { ErrorHelper } from '../error-helper/error-helper';
 import {
   FormFieldValidatorCommon,
   FormFieldValidatorDate,

--- a/packages/react-forms/src/lib/form-field-file-renderer/form-field-file-renderer.module.scss
+++ b/packages/react-forms/src/lib/form-field-file-renderer/form-field-file-renderer.module.scss
@@ -1,0 +1,30 @@
+.FileInputWrapper {
+  > input {
+    visibility: hidden;
+    width: 0;
+  }
+
+  > button {
+    margin: 0;
+    padding-left: 0;
+    padding-right: 0;
+    color: var(--f-color-type-light);
+
+    > span {
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+  }
+}
+
+.FileItem {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin: 0;
+  .f-Icon {
+    margin: 0;
+  }
+}

--- a/packages/react-forms/src/lib/form-field-file-renderer/form-field-file-renderer.tsx
+++ b/packages/react-forms/src/lib/form-field-file-renderer/form-field-file-renderer.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components';
 import { FormFieldRendererProps } from '../../types/renderer';
 import { FormFieldFile } from '../../types/fields';
 import { buildValidationRules, classNames, isRequired } from '../../utils';
@@ -12,50 +11,9 @@ import {
   theme as flamingo,
   UiText,
 } from '@heetch/flamingo-react';
-import { ErrorHelper } from '../styled-components';
+import { ErrorHelper } from '../error-helper/error-helper';
 import { useRef } from 'react';
-
-const FileInputWrapper = styled.div`
-  > input {
-    visibility: hidden;
-    width: 0;
-  }
-
-  > button {
-    margin: 0;
-    padding-left: 0;
-    padding-right: 0;
-    color: ${flamingo.color_v3.type.light};
-    > span {
-      font-weight: 500;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-  }
-`;
-
-const FileFieldWrapper = styled.div`
-  margin-top: 8px;
-  display: flex;
-  gap: 8px 16px;
-  align-items: center;
-  flex-wrap: wrap;
-`;
-
-const FileItem = styled(UiText).attrs({
-  variant: 'subContent',
-  textColor: flamingo.color_v3.type.default,
-})`
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  margin: 0;
-
-  .f-Icon {
-    margin: 0;
-  }
-`;
+import styles from './form-field-file-renderer.module.scss';
 
 export function FormFieldFileRenderer({
   field,
@@ -107,23 +65,31 @@ export function FormFieldFileRenderer({
         return (
           <div className={classNames.field.file.base}>
             {label && <Label htmlFor={fieldProps.name}>{label}</Label>}
-            <FileFieldWrapper className={classNames.field.file.list}>
+            <div className={classNames.field.file.list}>
               {files?.map((file) => (
-                <FileItem
+                <UiText
                   key={file.name}
-                  className={classNames.field.file.item}
+                  variant="subContent"
+                  textColor={flamingo.color_v3.type.default}
+                  className={[
+                    styles['FileItem'],
+                    classNames.field.file.item,
+                  ].join(' ')}
                 >
                   <IconButton
                     icon="IconTrash"
                     onClick={() => deleteFile(file)}
                   />{' '}
                   <span>{file.name}</span>
-                </FileItem>
+                </UiText>
               ))}
 
-              <FileInputWrapper
+              <div
                 data-testid="file"
-                className={classNames.field.file.input_wrapper}
+                className={[
+                  styles['FileInputWrapper'],
+                  classNames.field.file.input_wrapper,
+                ].join(' ')}
               >
                 <input
                   ref={fileInputRef}
@@ -142,8 +108,8 @@ export function FormFieldFileRenderer({
                     {placeholder}
                   </Button>
                 )}
-              </FileInputWrapper>
-            </FileFieldWrapper>
+              </div>
+            </div>
             {helper && <Helper>{helper}</Helper>}
             {errorHelper && <ErrorHelper>{errorHelper}</ErrorHelper>}
           </div>

--- a/packages/react-forms/src/lib/form-layout/form-layout.module.scss
+++ b/packages/react-forms/src/lib/form-layout/form-layout.module.scss
@@ -1,0 +1,11 @@
+.FormLayout {
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
+}
+
+.FormLayoutRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}

--- a/packages/react-forms/src/lib/form-layout/form-layout.stories.tsx
+++ b/packages/react-forms/src/lib/form-layout/form-layout.stories.tsx
@@ -1,14 +1,8 @@
-import { Story, Meta } from '@storybook/react';
+import { Meta, Story } from '@storybook/react';
 import { FormLayoutCell, FormLayoutRow } from './form-layout';
-import styled from 'styled-components';
 import { FormCell } from '../../types/layout';
 
 type LayoutStoryProps = { cells: FormCell[] };
-
-const CellContent = styled.div`
-  background-color: lightpink;
-  padding: 4px;
-`;
 
 export default {
   title: 'Components/Layout',
@@ -18,7 +12,14 @@ const Template: Story<LayoutStoryProps> = (args) => (
   <FormLayoutRow>
     {args.cells.map((cell) => (
       <FormLayoutCell key={cell.field} {...cell}>
-        <CellContent>{cell.field}</CellContent>
+        <div
+          style={{
+            backgroundColor: 'lightpink',
+            padding: '4px',
+          }}
+        >
+          {cell.field}
+        </div>
       </FormLayoutCell>
     ))}
   </FormLayoutRow>

--- a/packages/react-forms/src/lib/form-layout/form-layout.tsx
+++ b/packages/react-forms/src/lib/form-layout/form-layout.tsx
@@ -1,39 +1,42 @@
-import styled, { css } from 'styled-components';
 import { FormCell } from '@heetch/react-forms';
-import { PropsWithChildren } from 'react';
+import { CSSProperties, HTMLProps, PropsWithChildren } from 'react';
 import { classNames } from '../../utils';
+import styles from './form-layout.module.scss';
 
-export const FormLayout = styled.form.attrs({ className: classNames.form })`
-  display: flex;
-  gap: 8px;
-  flex-direction: column;
-`;
+export const FormLayout = ({
+  children,
+  ...formProps
+}: PropsWithChildren<HTMLProps<HTMLFormElement>>) => {
+  return (
+    <form
+      className={[styles['FormLayout'], classNames.form].join(' ')}
+      {...formProps}
+    >
+      {children}
+    </form>
+  );
+};
 
-export const FormLayoutRow = styled.div.attrs({
-  className: classNames.layout.row,
-})`
-  display: flex;
-  gap: 8px;
-  justify-content: baseline;
-  align-items: center;
-`;
+export const FormLayoutRow = ({ children }: PropsWithChildren) => {
+  return (
+    <div className={[styles['FormLayoutRow'], classNames.layout.row].join(' ')}>
+      {children}
+    </div>
+  );
+};
 
 export const FormLayoutCell = ({
   widthConstraint,
   children,
 }: PropsWithChildren<FormCell>) => {
-  return <StyledCell widthConstraint={widthConstraint}>{children}</StyledCell>;
-};
-
-const StyledCell = styled.div.attrs({ className: classNames.layout.cell })<
-  Pick<FormCell, 'widthConstraint'>
->`
-  ${({ widthConstraint }) =>
+  const cellStyle: CSSProperties =
     typeof widthConstraint === 'string'
-      ? css`
-          width: ${widthConstraint};
-        `
-      : css`
-          flex: ${widthConstraint || 1};
-        `}
-`;
+      ? { width: widthConstraint }
+      : { flex: widthConstraint || 1 };
+
+  return (
+    <div style={cellStyle} className={classNames.layout.cell}>
+      {children}
+    </div>
+  );
+};

--- a/packages/react-forms/src/lib/styled-components.tsx
+++ b/packages/react-forms/src/lib/styled-components.tsx
@@ -1,7 +1,0 @@
-import { Helper, theme as flamingo } from '@heetch/flamingo-react';
-import styled from 'styled-components';
-
-export const ErrorHelper = styled(Helper)`
-  margin-top: 0;
-  color: ${flamingo.color_v3.feedback.error} !important;
-`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,13 +1885,16 @@ __metadata:
 "@heetch/react-forms@workspace:packages/react-forms":
   version: 0.0.0-use.local
   resolution: "@heetch/react-forms@workspace:packages/react-forms"
+  dependencies:
+    "@react-hook/window-size": ^3.1.1
+    react-hook-form: ^7.35.0
   peerDependencies:
     "@heetch/flamingo-react": ^5.2.0
     "@react-hook/window-size": ^3.1.1
     react: 18.2.0
     react-dom: 18.2.0
     react-hook-form: ^7.35.0
-    styled-components: 5.3.5
+    styled-components: ^5.1.0
   languageName: unknown
   linkType: soft
 
@@ -1910,7 +1913,6 @@ __metadata:
     "@nrwl/storybook": 14.8.4
     "@nrwl/web": 14.8.4
     "@nrwl/workspace": 14.8.4
-    "@react-hook/window-size": ^3.1.1
     "@storybook/addon-actions": ^6.5.12
     "@storybook/addon-essentials": ~6.5.9
     "@storybook/addon-interactions": ^6.5.12
@@ -1949,12 +1951,11 @@ __metadata:
     prettier: ^2.6.2
     react: 18.2.0
     react-dom: 18.2.0
-    react-hook-form: ^7.35.0
     react-is: 18.2.0
     react-test-renderer: 18.2.0
     regenerator-runtime: 0.13.7
     rollup-plugin-terser: ^7.0.2
-    styled-components: 5.3.5
+    styled-components: ^5.1.0
     ts-jest: 28.0.5
     ts-node: 10.9.1
     tslib: ^2.3.0
@@ -19146,7 +19147,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-components@npm:5.3.5, styled-components@npm:^5.1.0":
+"styled-components@npm:^5.1.0":
   version: 5.3.5
   resolution: "styled-components@npm:5.3.5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,7 +1894,6 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-hook-form: ^7.35.0
-    styled-components: ^5.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR removes usage of styled-components within react-forms. Its benefits were not huge, yet it was sometimes problematic to import the library in some apps. 
It has been replaced by SCSS modules, supported out of the box by the build system provided by Nx. 