### PR TITLE
Bump cypress-mock-openapi version

### DIFF
--- a/packages/cypress-mock-openapi/package.json
+++ b/packages/cypress-mock-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heetch/cypress-mock-openapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Cypress command to stub network requests using OpenAPI examples",
   "main": "./dist/index.js",
   "repository": "https://github.com/heetch/web-tools",


### PR DESCRIPTION
I'm not sure how that happened but there is already a 1.0.1 published but still with the old repo links: https://www.npmjs.com/package/@heetch/cypress-mock-openapi

This PR bumps the version again so I can republish. 