### PR TITLE
fix: Number fields validation

### DIFF
--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heetch/react-forms",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "author": "Heetch",
   "devDependencies": {

--- a/packages/react-forms/src/lib/form-field-number-renderer/form-field-number-renderer.stories.tsx
+++ b/packages/react-forms/src/lib/form-field-number-renderer/form-field-number-renderer.stories.tsx
@@ -102,8 +102,8 @@ _tests.play = async () => {
   const input: HTMLInputElement = screen.getByLabelText('Amount', {
     selector: 'input',
   });
-  await userEvent.type(input, '1. ', { delay: 50 });
-  expect(input).toHaveStyle({ color: '#cd2703' });
-  await userEvent.type(input, '1.5 ', { delay: 50 });
+  await userEvent.type(input, '1.5', { delay: 50 });
+  expect(input).not.toHaveStyle({ color: '#cd2703' });
+  await userEvent.clear(input);
   expect(input).not.toHaveStyle({ color: '#cd2703' });
 };

--- a/packages/react-forms/src/lib/form-field-number-renderer/form-field-number-renderer.tsx
+++ b/packages/react-forms/src/lib/form-field-number-renderer/form-field-number-renderer.tsx
@@ -64,9 +64,19 @@ function NumberFieldRenderer({
   );
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    fieldProps.onChange(
-      e.target.value === '' ? undefined : parseFloat(e.target.value)
-    );
+    if (e.target.value === '') {
+      if (e.target.validity.valid) {
+        // Actually empty
+        fieldProps.onChange(undefined);
+      } else {
+        // Not empty but something that cannot be parsed as a number
+        fieldProps.onChange(NaN);
+      }
+    } else {
+      fieldProps.onChange(
+        parseFloat(e.target.value));
+    }
+
     setValue(e.target.value);
   };
 

--- a/packages/react-forms/src/utils.ts
+++ b/packages/react-forms/src/utils.ts
@@ -116,7 +116,10 @@ function buildValidationRulesNumber(
       validate: {
         ...(baseRules?.validate || {}),
         integer: (value: number) =>
-          Number.isInteger(value) || texts?.errors?.integer || false,
+          value === undefined ||
+          Number.isInteger(value) ||
+          texts?.errors?.integer ||
+          false,
       },
     };
   } else {
@@ -124,8 +127,13 @@ function buildValidationRulesNumber(
       ...(baseRules || {}),
       validate: {
         ...(baseRules?.validate || {}),
-        number: (value: number) =>
-          !isNaN(value) || texts?.errors?.number || false,
+        number: (value: number) => {
+          console.log(value, typeof value, isNaN(value));
+          return value === undefined ||
+          !isNaN(value) ||
+          texts?.errors?.number ||
+          false;
+        },
       },
     };
   }


### PR DESCRIPTION
This PR fixes the validation of number fields. Even if not `required`, the validators for integer and decimal values tried to parse empty string as numbers. 

The tricky part is the browser pre-parse the value and registers an empty value in both cases : if the user actually cleared the field and also when he typed something wrong like `1.`. To differentiate we need to look at the `validity` property of the field.